### PR TITLE
Revert "Set and Get auth provider."

### DIFF
--- a/src/RequestAdapter.php
+++ b/src/RequestAdapter.php
@@ -2,7 +2,6 @@
 namespace Microsoft\Kiota\Abstractions;
 
 use Http\Promise\Promise;
-use Microsoft\Kiota\Abstractions\Authentication\AuthenticationProvider;
 use Microsoft\Kiota\Abstractions\Serialization\ParseNodeFactory;
 use Microsoft\Kiota\Abstractions\Serialization\SerializationWriterFactory;
 use Microsoft\Kiota\Abstractions\Store\BackingStoreFactory;
@@ -87,17 +86,4 @@ interface RequestAdapter {
      * @return string The base url for every request.
      */
     public function getBaseUrl(): string;
-
-    /**
-     * Set a custom authentication provider for the request adapter.
-     * @param AuthenticationProvider $authenticationProvider
-     * @return void
-     */
-    public function setAuthenticationProvider(AuthenticationProvider $authenticationProvider): void;
-
-    /**
-     * Get the current authentication provider for the request adapter.
-     * @return AuthenticationProvider
-     */
-    public function getAuthenticationProvider(): AuthenticationProvider;
 }


### PR DESCRIPTION
The issue that needed this workaround has been fixed in [Fix/allowed host validation by SilasKenneth · Pull Request #3 · microsoft/kiota-authentication-phpleague-php (github.com)](https://github.com/microsoft/kiota-authentication-phpleague-php/pull/3)
Reverts microsoft/kiota-abstractions-php#6