### PR TITLE
Support `Parsable` collections & scalar types in the request body

### DIFF
--- a/src/RequestInformation.php
+++ b/src/RequestInformation.php
@@ -158,8 +158,8 @@ class RequestInformation {
             $writer->writeObjectValue(null, $value);
             $this->headers[self::$contentTypeHeader] = $contentType;
             $this->content = $writer->getSerializedContent();
-        } catch (Exception $ex) {
-            throw new RuntimeException('could not serialize payload.', 1, $ex);
+        } catch (Exception $exception) {
+            throw new RuntimeException('could not serialize payload.', 1, $exception);
         }
     }
 
@@ -178,8 +178,8 @@ class RequestInformation {
             $writer->writeCollectionOfObjectValues(null, $values);
             $this->headers[self::$contentTypeHeader] = $contentType;
             $this->content = $writer->getSerializedContent();
-        } catch (Exception $ex) {
-            throw new RuntimeException('could not serialize payload.', 1, $ex);
+        } catch (Exception $exception) {
+            throw new RuntimeException('could not serialize payload.', 1, $exception);
         }
     }
 
@@ -197,8 +197,8 @@ class RequestInformation {
             $writer->writeAnyValue(null, $value);
             $this->headers[self::$contentTypeHeader] = $contentType;
             $this->content = $writer->getSerializedContent();
-        } catch (Exception $ex) {
-            throw new RuntimeException('could not serialize payload.', 1, $ex);
+        } catch (Exception $exception) {
+            throw new RuntimeException('could not serialize payload.', 1, $exception);
         }
     }
 
@@ -216,8 +216,8 @@ class RequestInformation {
             $writer->writeCollectionOfPrimitiveValues(null, $values);
             $this->headers[self::$contentTypeHeader] = $contentType;
             $this->content = $writer->getSerializedContent();
-        } catch (Exception $ex) {
-            throw new RuntimeException('could not serialize payload.', 1, $ex);
+        } catch (Exception $exception) {
+            throw new RuntimeException('could not serialize payload.', 1, $exception);
         }
     }
 

--- a/src/Serialization/SerializationWriterFactoryRegistry.php
+++ b/src/Serialization/SerializationWriterFactoryRegistry.php
@@ -49,7 +49,7 @@ class SerializationWriterFactoryRegistry implements SerializationWriterFactory {
         if (array_key_exists($cleanedContentType, $this->contentTypeAssociatedFactories)) {
             return $this->contentTypeAssociatedFactories[$cleanedContentType]->getSerializationWriter($cleanedContentType);
         }
-        throw new UnexpectedValueException('Content type ' . $contentType . ' does not have a factory to be parsed');
+        throw new UnexpectedValueException('Content type ' . $contentType . ' does not have a factory to be parsed. Add a SerializationWriter factory to support the content type.');
     }
 
     public function getValidContentType(): string {


### PR DESCRIPTION
- support passing scalar values as the request body
- refactor setting collection request bodies

part of https://github.com/microsoft/kiota/issues/1933