### PR TITLE
Make `getAdditionalData()` return nullable

### DIFF
--- a/src/Serialization/AdditionalDataHolder.php
+++ b/src/Serialization/AdditionalDataHolder.php
@@ -5,9 +5,9 @@ namespace Microsoft\Kiota\Abstractions\Serialization;
 interface AdditionalDataHolder {
     /**
      * Gets the additional data for this object that did not belong to the properties.
-     * @return array<string,mixed> The additional data for this object.
+     * @return array<string,mixed>|null The additional data for this object.
      */
-    public function getAdditionalData(): array;
+    public function getAdditionalData(): ?array;
 
     /**
      * Sets the additional data for this object that did not belong to the properties.


### PR DESCRIPTION
When backing store is enabled, a model getter can always return `null` when dirty tracking is enabled and the property hasn't changed since initialisation.

part of https://github.com/microsoftgraph/msgraph-sdk-php/issues/979