### PR TITLE
Bump annotations package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"php-http/promise": "^1.1.0",
 		"php-http/message-factory": "^1.0.2",
 		"league/uri": "^6.5",
-		"doctrine/annotations": "^1.13",
+		"doctrine/annotations": "^2.0",
 		"ramsey/uuid": "^3 || ^4"
 	},
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"php-http/promise": "^1.1.0",
 		"php-http/message-factory": "^1.0.2",
 		"league/uri": "^6.5",
-		"doctrine/annotations": "^2.0",
+		"doctrine/annotations": "^1.13 || ^2.0",
 		"ramsey/uuid": "^3 || ^4"
 	},
     "require-dev": {

--- a/src/RequestInformation.php
+++ b/src/RequestInformation.php
@@ -47,7 +47,6 @@ class RequestInformation {
     public function __construct()
     {
         // Init annotation utils
-        AnnotationRegistry::registerLoader('class_exists');
         self::$annotationReader = new AnnotationReader();
     }
 

--- a/tests/RequestInformationTest.php
+++ b/tests/RequestInformationTest.php
@@ -111,6 +111,7 @@ class RequestInformationTest extends TestCase {
 
 class TestQueryParameter {
     /**
+     * @var string[]|null
      * @QueryParameter("%24select")
      */
     public ?array $select = null;


### PR DESCRIPTION
We use a custom annotation [type](https://github.com/microsoft/kiota-abstractions-php/blob/dev/src/QueryParameter.php#L16) to hold the URL encoded query parameter name to be resolved with the request URL template - see [example annotation in use](https://github.com/microsoftgraph/msgraph-sdk-php/blob/feat/kiota-preview/src/Generated/Users/UsersRequestBuilderGetQueryParameters.php#L10) & the corresponding [URL template](https://github.com/microsoftgraph/msgraph-sdk-php/blob/feat/kiota-preview/src/Generated/Users/UsersRequestBuilder.php#L75)

This is supported by the [`doctrine/annotations`](https://packagist.org/packages/doctrine/annotations) package which was initially designed to use custom autoloading functionality for annotation classes. As of version [1.10.0](https://github.com/doctrine/annotations/releases/tag/1.10.0) a fallback to the default registered autoloaders was provided for in case a custom autoloader is not provided. In the case of our package, Composer registers default autoloaders for classes based on our [config](https://github.com/microsoft/kiota-abstractions-php/blob/dev/composer.json#L14)

Use of custom autoloading has been deprecated in v2.0 & we didn't need to have specified it in the first place.

### This PR 
- deprecates the custom autoloading step supporting both v1.13+ and v2.0

Side Note: PHP 8 provides annotations ("attributes") out of the box - https://github.com/microsoft/kiota/issues/1526