### PR TITLE
Remove response handler from request adapter

### DIFF
--- a/src/NativeResponseHandler.php
+++ b/src/NativeResponseHandler.php
@@ -11,7 +11,14 @@ use Http\Promise\Promise;
  */
 class NativeResponseHandler implements ResponseHandler
 {
-    public function handleResponseAsync(ResponseInterface $response): Promise
+    /**
+     * Returns a promise that resolves to the raw PSR-7 response
+     *
+     * @param ResponseInterface $response
+     * @param arrayarray<string, array{string, string}>|null $errorMappings
+     * @return Promise
+     */
+    public function handleResponseAsync(ResponseInterface $response, ?array $errorMappings = null): Promise
     {
         return new FulfilledPromise($response);
     }

--- a/src/NativeResponseHandler.php
+++ b/src/NativeResponseHandler.php
@@ -15,7 +15,7 @@ class NativeResponseHandler implements ResponseHandler
      * Returns a promise that resolves to the raw PSR-7 response
      *
      * @param ResponseInterface $response
-     * @param arrayarray<string, array{string, string}>|null $errorMappings
+     * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise
      */
     public function handleResponseAsync(ResponseInterface $response, ?array $errorMappings = null): Promise

--- a/src/RequestAdapter.php
+++ b/src/RequestAdapter.php
@@ -15,7 +15,11 @@ interface RequestAdapter {
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise with the deserialized response model.
      */
-    public function sendAsync(RequestInformation $requestInfo, array $targetCallable, ?array $errorMappings = null): Promise;
+    public function sendAsync(
+        RequestInformation $requestInfo,
+        array $targetCallable,
+        ?array $errorMappings = null
+    ): Promise;
 
     /**
      * Gets the serialization writer factory currently in use for the HTTP core service.
@@ -37,7 +41,11 @@ interface RequestAdapter {
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise with the deserialized response model collection.
      */
-    public function sendCollectionAsync(RequestInformation $requestInfo, array $targetCallable, ?array $errorMappings = null): Promise;
+    public function sendCollectionAsync(
+        RequestInformation $requestInfo,
+        array $targetCallable,
+        ?array $errorMappings = null
+    ): Promise;
 
     /**
      * Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
@@ -46,7 +54,11 @@ interface RequestAdapter {
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise
      */
-    public function sendPrimitiveAsync(RequestInformation $requestInfo, string $primitiveType, ?array $errorMappings = null): Promise;
+    public function sendPrimitiveAsync(
+        RequestInformation $requestInfo,
+        string $primitiveType,
+        ?array $errorMappings = null
+    ): Promise;
 
     /**
      * Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
@@ -55,7 +67,11 @@ interface RequestAdapter {
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise
      */
-    public function sendPrimitiveCollectionAsync(RequestInformation $requestInfo, string $primitiveType, ?array $errorMappings = null): Promise;
+    public function sendPrimitiveCollectionAsync(
+        RequestInformation $requestInfo,
+        string $primitiveType,
+        ?array $errorMappings = null
+    ): Promise;
 
     /**
      * Executes the HTTP request specified by the given RequestInformation with no return content.

--- a/src/RequestAdapter.php
+++ b/src/RequestAdapter.php
@@ -12,11 +12,10 @@ interface RequestAdapter {
      * Executes the HTTP request specified by the given RequestInformation and returns the deserialized response model.
      * @param RequestInformation $requestInfo the request info to execute.
      * @param array{string, string} $targetCallable the class of the response model to deserialize the response into.
-     * @param ResponseHandler|null $responseHandler The response handler to use for the HTTP request instead of the default handler.
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise with the deserialized response model.
      */
-    public function sendAsync(RequestInformation $requestInfo, array $targetCallable, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise;
+    public function sendAsync(RequestInformation $requestInfo, array $targetCallable, ?array $errorMappings = null): Promise;
 
     /**
      * Gets the serialization writer factory currently in use for the HTTP core service.
@@ -35,40 +34,36 @@ interface RequestAdapter {
      * Executes the HTTP request specified by the given RequestInformation and returns the deserialized response model collection.
      * @param RequestInformation $requestInfo the request info to execute.
      * @param array{string, string} $targetCallable the callable representing object creation logic.
-     * @param ResponseHandler|null $responseHandler
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise with the deserialized response model collection.
      */
-    public function sendCollectionAsync(RequestInformation $requestInfo, array $targetCallable, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise;
+    public function sendCollectionAsync(RequestInformation $requestInfo, array $targetCallable, ?array $errorMappings = null): Promise;
 
     /**
      * Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
      * @param RequestInformation $requestInfo
      * @param string $primitiveType e.g. int, bool
-     * @param ResponseHandler|null $responseHandler
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise
      */
-    public function sendPrimitiveAsync(RequestInformation $requestInfo, string $primitiveType, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise;
+    public function sendPrimitiveAsync(RequestInformation $requestInfo, string $primitiveType, ?array $errorMappings = null): Promise;
 
     /**
      * Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model collection.
      * @param RequestInformation $requestInfo
      * @param string $primitiveType e.g. int, bool
-     * @param ResponseHandler|null $responseHandler
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise
      */
-    public function sendPrimitiveCollectionAsync(RequestInformation $requestInfo, string $primitiveType, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise;
+    public function sendPrimitiveCollectionAsync(RequestInformation $requestInfo, string $primitiveType, ?array $errorMappings = null): Promise;
 
     /**
      * Executes the HTTP request specified by the given RequestInformation with no return content.
      * @param RequestInformation $requestInfo
-     * @param ResponseHandler|null $responseHandler
      * @param array<string, array{string, string}>|null $errorMappings
      * @return Promise
      */
-    public function sendNoContentAsync(RequestInformation $requestInfo, ?ResponseHandler $responseHandler = null, ?array $errorMappings = null): Promise;
+    public function sendNoContentAsync(RequestInformation $requestInfo, ?array $errorMappings = null): Promise;
     /**
      * Enables the backing store proxies for the SerializationWriters and ParseNodes in use.
      * @param BackingStoreFactory $backingStoreFactory The backing store factory to use.

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -8,7 +8,8 @@ interface ResponseHandler {
     /**
      * Callback method that is invoked when a response is received.
      * @param ResponseInterface $response The native response object.
+     * @param array<string, array{string, string}>|null $errorMappings map of error status codes to  exception models to deserialize to
      * @return Promise A Promise that represents the asynchronous operation and contains the deserialized response.
      */
-    public function handleResponseAsync(ResponseInterface $response): Promise;
+    public function handleResponseAsync(ResponseInterface $response, ?array $errorMappings = null): Promise;
 }

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -8,7 +8,7 @@ interface ResponseHandler {
     /**
      * Callback method that is invoked when a response is received.
      * @param ResponseInterface $response The native response object.
-     * @param array<string, array{string, string}>|null $errorMappings map of error status codes to  exception models to deserialize to
+     * @param array<string, array<string, string>>|null $errorMappings map of error status codes to  exception models to deserialize to
      * @return Promise A Promise that represents the asynchronous operation and contains the deserialized response.
      */
     public function handleResponseAsync(ResponseInterface $response, ?array $errorMappings = null): Promise;

--- a/src/ResponseHandler.php
+++ b/src/ResponseHandler.php
@@ -8,7 +8,8 @@ interface ResponseHandler {
     /**
      * Callback method that is invoked when a response is received.
      * @param ResponseInterface $response The native response object.
-     * @param array<string, array<string, string>>|null $errorMappings map of error status codes to  exception models to deserialize to
+     * @param array<string, array<string, string>>|null $errorMappings map of error status codes to  exception models
+     * to deserialize to
      * @return Promise A Promise that represents the asynchronous operation and contains the deserialized response.
      */
     public function handleResponseAsync(ResponseInterface $response, ?array $errorMappings = null): Promise;


### PR DESCRIPTION
part of https://github.com/microsoft/kiota/issues/1856

This PR
- Removes the response handler parameter from the `GuzzleRequestAdapter` send methods
- Adds error mappings as a param in the `ResponseHandler` interface method to align with other SDKs
- Updates the native response handler to accept the error mappings