### PR TITLE
Return empty if request header key doesn't exist

### DIFF
--- a/src/RequestHeaders.php
+++ b/src/RequestHeaders.php
@@ -24,13 +24,11 @@ class RequestHeaders
     /**
      * Get values for a specific header with a specific key.
      * @param string $key
-     * @return array<string>|null
+     * @return array<string>
      */
-    public function get(string $key): ?array
+    public function get(string $key): array
     {
-        $key = $this->normalize($key);
-        $keyExists = $this->headers[$key] ?? false;
-        return $keyExists ? array_keys($this->headers[$key]) : null;
+        return array_keys($this->headers[$this->normalize($key)] ?? []);
     }
 
     /**

--- a/tests/RequestHeadersTest.php
+++ b/tests/RequestHeadersTest.php
@@ -19,7 +19,7 @@ class RequestHeadersTest extends TestCase
 
     public function testGetNonExistentKey(): void
     {
-        $this->assertNull((new RequestHeaders)->get("abc"));
+        $this->assertEmpty((new RequestHeaders)->get("abc"));
     }
 
     public function testGetAll(): void
@@ -63,7 +63,7 @@ class RequestHeadersTest extends TestCase
         $headers->remove('User-Agent');
         $this->assertEquals(1, $headers->count());
         $this->assertCount(2, $headers->get('Content-Type'));
-        $this->assertNull($headers->get('User-Agent'));
+        $this->assertEmpty($headers->get('User-Agent'));
     }
 
     public function testContains(): void


### PR DESCRIPTION
Matches the PSR pattern better - https://github.com/guzzle/psr7/blob/master/src/MessageTrait.php#L53