### PR TITLE
Add generics PHPDoc tags to ParseNode methods

### DIFF
--- a/src/Serialization/ParseNode.php
+++ b/src/Serialization/ParseNode.php
@@ -43,14 +43,16 @@ interface ParseNode {
 
     /**
      * Gets the model object value of the node.
-     * @param array{string,string} $type The type for the Parsable object.
-     * @return Parsable|null the model object value of the node.
+     * @template T of Parsable
+     * @param array{class-string<T>,string} $type The type for the Parsable object.
+     * @return T|null the model object value of the node.
      */
     public function getObjectValue(array $type): ?Parsable;
 
     /**
-     * @param array{string,string} $type The underlying type for the Parsable class.
-     * @return array<Parsable>|null An array of Parsable values.
+     * @template T of Parsable
+     * @param array{class-string<T>,string} $type The underlying type for the Parsable class.
+     * @return array<T>|null An array of Parsable values.
      */
     public function getCollectionOfObjectValues(array $type): ?array;
 
@@ -87,14 +89,16 @@ interface ParseNode {
 
     /**
      * Gets the Enum value of the node.
-     * @param string $targetEnum
-     * @return Enum|null the Enum value of the node.
+     * @template T of Enum
+     * @param class-string<T> $targetEnum
+     * @return T|null the Enum value of the node.
      */
     public function getEnumValue(string $targetEnum): ?Enum;
 
     /**
-     * @param string $targetClass
-     * @return Enum[]|null
+     * @template T of Enum
+     * @param class-string<T> $targetClass
+     * @return array<T>|null
      */
     public function getCollectionOfEnumValues(string $targetClass): ?array;
 


### PR DESCRIPTION
PHP doesn't support generics. The return type of our `ParseNode` object methods is a `Parsable` and `Enum` for enum-related methods yet model setters expect a concrete type. This causes static analysis failures like:

```
Error: Parameter #1 $value of method Integration\Test\Client\Models\AppPermissions::setPages() expects Integration\Test\Client\Models\AppPermissions_pages|null, Microsoft\Kiota\Abstractions\Enum|null given.
Error: Parameter #1 $value of method Integration\Test\Client\Models\TestList::setItems() expects array<Integration\Test\Client\Models\TestList_items>|null, array<Microsoft\Kiota\Abstractions\Serialization\Parsable>|null given.
Error: Parameter #1 $value of method Integration\Test\Client\Models\TestList_items::setAdditional() expects Integration\Test\Client\Models\TestList_items_additional|null, Microsoft\Kiota\Abstractions\Serialization\Parsable|null given.
```

This change tells PHPStan that a generic type will be passed and returned.

Impact of this change can be viewed at https://github.com/microsoft/kiota-samples/actions/runs/4383543674/jobs/7673923173 where PHPStan is run using abstractions changes from this branch. The only existing issue is around arrays of primitive types. Arrays of Parsable implementations/Arrays of Enums are handled.

Still need to figure out a fix for the PHPDoc for `getCollectionOfPrimitiveValues`. The generic PHPDoc format doesn't match primitive types.

part of https://github.com/microsoft/kiota/issues/2378