### PR TITLE
CAE support - Allow auth layer to receive claims

### DIFF
--- a/src/Authentication/AccessTokenProvider.php
+++ b/src/Authentication/AccessTokenProvider.php
@@ -27,7 +27,7 @@ interface AccessTokenProvider
      * Returns a Promise that is fulfilled with the access token string
      *
      * @param string $url the target URI to get an access token for
-     * @param array $additionalAuthenticationContext
+     * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
     public function getAuthorizationTokenAsync(string $url, array $additionalAuthenticationContext = []): Promise;

--- a/src/Authentication/AccessTokenProvider.php
+++ b/src/Authentication/AccessTokenProvider.php
@@ -27,9 +27,10 @@ interface AccessTokenProvider
      * Returns a Promise that is fulfilled with the access token string
      *
      * @param string $url the target URI to get an access token for
+     * @param array $additionalAuthenticationContext
      * @return Promise
      */
-    public function getAuthorizationTokenAsync(string $url): Promise;
+    public function getAuthorizationTokenAsync(string $url, array $additionalAuthenticationContext = []): Promise;
 
     /**
      * Returns the {@link AllowedHostsValidator} instance used by the AccessTokenProvider

--- a/src/Authentication/AnonymousAuthenticationProvider.php
+++ b/src/Authentication/AnonymousAuthenticationProvider.php
@@ -13,7 +13,11 @@ class AnonymousAuthenticationProvider implements AuthenticationProvider {
      * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
-    public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {
+    public function authenticateRequest(
+        RequestInformation $request,
+        array $additionalAuthenticationContext = []
+    ): Promise
+    {
         return new FulfilledPromise(null);
     }
 }

--- a/src/Authentication/AnonymousAuthenticationProvider.php
+++ b/src/Authentication/AnonymousAuthenticationProvider.php
@@ -10,9 +10,10 @@ class AnonymousAuthenticationProvider implements AuthenticationProvider {
 
     /**
      * @param RequestInformation $request Request information
+     * @param array $additionalAuthenticationContext
      * @return Promise
      */
-    public function authenticateRequest(RequestInformation $request): Promise {
+    public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {
         return new FulfilledPromise(null);
     }
 }

--- a/src/Authentication/AnonymousAuthenticationProvider.php
+++ b/src/Authentication/AnonymousAuthenticationProvider.php
@@ -10,7 +10,7 @@ class AnonymousAuthenticationProvider implements AuthenticationProvider {
 
     /**
      * @param RequestInformation $request Request information
-     * @param array $additionalAuthenticationContext
+     * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
     public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {

--- a/src/Authentication/AuthenticationProvider.php
+++ b/src/Authentication/AuthenticationProvider.php
@@ -17,7 +17,7 @@ use Microsoft\Kiota\Abstractions\RequestInformation;
 interface AuthenticationProvider {
     /**
      * @param RequestInformation $request
-     * @param array $additionalAuthenticationContext
+     * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
     public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise;

--- a/src/Authentication/AuthenticationProvider.php
+++ b/src/Authentication/AuthenticationProvider.php
@@ -17,7 +17,8 @@ use Microsoft\Kiota\Abstractions\RequestInformation;
 interface AuthenticationProvider {
     /**
      * @param RequestInformation $request
+     * @param array $additionalAuthenticationContext
      * @return Promise
      */
-    public function authenticateRequest(RequestInformation $request): Promise;
+    public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise;
 }

--- a/src/Authentication/AuthenticationProvider.php
+++ b/src/Authentication/AuthenticationProvider.php
@@ -20,5 +20,8 @@ interface AuthenticationProvider {
      * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
-    public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise;
+    public function authenticateRequest(
+        RequestInformation $request,
+        array $additionalAuthenticationContext = []
+    ): Promise;
 }

--- a/src/Authentication/BaseBearerTokenAuthenticationProvider.php
+++ b/src/Authentication/BaseBearerTokenAuthenticationProvider.php
@@ -61,6 +61,13 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
      * @return Promise
      */
     public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {
+        if ($additionalAuthenticationContext
+            && $additionalAuthenticationContext[self::$claimsKey] ?? null
+            && $request->getHeaders()->contains(self::$authorizationHeaderKey)
+        ) {
+            $request->getHeaders()->remove(self::$authorizationHeaderKey);
+        }
+
         if (!$request->getHeaders()->contains(self::$authorizationHeaderKey)) {
             return $this->getAccessTokenProvider()->getAuthorizationTokenAsync($request->getUri(), $additionalAuthenticationContext)
                         ->then(function ($token) use($request) {

--- a/src/Authentication/BaseBearerTokenAuthenticationProvider.php
+++ b/src/Authentication/BaseBearerTokenAuthenticationProvider.php
@@ -57,7 +57,7 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
 
     /**
      * @param RequestInformation $request
-     * @param array $additionalAuthenticationContext
+     * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
     public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {

--- a/src/Authentication/BaseBearerTokenAuthenticationProvider.php
+++ b/src/Authentication/BaseBearerTokenAuthenticationProvider.php
@@ -60,7 +60,11 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
      * @param array<string, mixed> $additionalAuthenticationContext
      * @return Promise
      */
-    public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {
+    public function authenticateRequest(
+        RequestInformation $request,
+        array $additionalAuthenticationContext = []
+    ): Promise
+    {
         if (array_key_exists(self::$claimsKey, $additionalAuthenticationContext)
             && $request->getHeaders()->contains(self::$authorizationHeaderKey)
         ) {
@@ -68,8 +72,9 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
         }
 
         if (!$request->getHeaders()->contains(self::$authorizationHeaderKey)) {
-            return $this->getAccessTokenProvider()->getAuthorizationTokenAsync($request->getUri(), $additionalAuthenticationContext)
-                        ->then(function ($token) use($request) {
+            return $this->getAccessTokenProvider()
+                        ->getAuthorizationTokenAsync($request->getUri(), $additionalAuthenticationContext)
+                        ->then(function ($token) use ($request) {
                             if ($token) {
                                 $request->addHeader(self::$authorizationHeaderKey, "Bearer {$token}");
                             }

--- a/src/Authentication/BaseBearerTokenAuthenticationProvider.php
+++ b/src/Authentication/BaseBearerTokenAuthenticationProvider.php
@@ -25,6 +25,13 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
     private static string $authorizationHeaderKey = "Authorization";
 
     /**
+     * Claims key to search for in $additionalAuthenticationContext
+     *
+     * @var string
+     */
+    private static string $claimsKey = "claims";
+
+    /**
      * @var AccessTokenProvider {@link AccessTokenProvider}
      */
     private AccessTokenProvider $accessTokenProvider;
@@ -50,12 +57,12 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
 
     /**
      * @param RequestInformation $request
+     * @param array $additionalAuthenticationContext
      * @return Promise
-     * @throws UriException
      */
-    public function authenticateRequest(RequestInformation $request): Promise {
+    public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {
         if (!$request->getHeaders()->contains(self::$authorizationHeaderKey)) {
-            return $this->getAccessTokenProvider()->getAuthorizationTokenAsync($request->getUri())
+            return $this->getAccessTokenProvider()->getAuthorizationTokenAsync($request->getUri(), $additionalAuthenticationContext)
                         ->then(function ($token) use($request) {
                             if ($token) {
                                 $request->addHeader(self::$authorizationHeaderKey, "Bearer {$token}");

--- a/src/Authentication/BaseBearerTokenAuthenticationProvider.php
+++ b/src/Authentication/BaseBearerTokenAuthenticationProvider.php
@@ -61,8 +61,7 @@ class BaseBearerTokenAuthenticationProvider implements AuthenticationProvider {
      * @return Promise
      */
     public function authenticateRequest(RequestInformation $request, array $additionalAuthenticationContext = []): Promise {
-        if ($additionalAuthenticationContext
-            && $additionalAuthenticationContext[self::$claimsKey] ?? null
+        if (array_key_exists(self::$claimsKey, $additionalAuthenticationContext)
             && $request->getHeaders()->contains(self::$authorizationHeaderKey)
         ) {
             $request->getHeaders()->remove(self::$authorizationHeaderKey);

--- a/tests/Authentication/AnonymousAuthenticationProviderTest.php
+++ b/tests/Authentication/AnonymousAuthenticationProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Microsoft\Kiota\Abstractions\Tests\Authentication;
+
+use Microsoft\Kiota\Abstractions\Authentication\AnonymousAuthenticationProvider;
+use Microsoft\Kiota\Abstractions\RequestInformation;
+use PHPUnit\Framework\TestCase;
+
+class AnonymousAuthenticationProviderTest extends TestCase
+{
+    public function testRequestNotManipulated(): void
+    {
+        $auth = new AnonymousAuthenticationProvider();
+        $request = new RequestInformation();
+        $request->urlTemplate = '{+baseurl}';
+        $request->pathParameters['baseurl'] = 'https://graph.microsoft.com';
+
+        $auth->authenticateRequest($request)->wait();
+        $this->assertEmpty($request->getHeaders()->get('Authorization'));
+
+        $auth->authenticateRequest($request, ['claims' => 'abc'])->wait();
+        $this->assertEmpty($request->getHeaders()->get('Authorization'));
+    }
+}

--- a/tests/Authentication/BaseBearerTokenAuthenticationProviderTest.php
+++ b/tests/Authentication/BaseBearerTokenAuthenticationProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Microsoft\Kiota\Abstractions\Tests\Authentication;
+
+use Http\Promise\FulfilledPromise;
+use Microsoft\Kiota\Abstractions\Authentication\AccessTokenProvider;
+use Microsoft\Kiota\Abstractions\Authentication\BaseBearerTokenAuthenticationProvider;
+use Microsoft\Kiota\Abstractions\RequestInformation;
+use PHPUnit\Framework\TestCase;
+
+class BaseBearerTokenAuthenticationProviderTest extends TestCase
+{
+    private AccessTokenProvider $accessTokenProvider;
+    private BaseBearerTokenAuthenticationProvider $baseBearerTokenAuthenticationProvider;
+    private RequestInformation $requestInformation;
+
+    protected function setUp(): void
+    {
+        $this->accessTokenProvider = $this->createStub(AccessTokenProvider::class);
+        $this->accessTokenProvider->method('getAuthorizationTokenAsync')->willReturn(new FulfilledPromise('abc'));
+        $this->baseBearerTokenAuthenticationProvider = new BaseBearerTokenAuthenticationProvider($this->accessTokenProvider);
+        $this->requestInformation = new RequestInformation();
+        $this->requestInformation->urlTemplate = '{+baseurl}';
+        $this->requestInformation->pathParameters['baseurl'] = 'https://graph.microsoft.com';
+    }
+
+    public function testAuthenticateRequestAddsTokenToHeader(): void
+    {
+        $this->baseBearerTokenAuthenticationProvider->authenticateRequest($this->requestInformation)->wait();
+        $this->assertTrue($this->requestInformation->getHeaders()->contains('Authorization'));
+        $this->assertEquals(['Bearer abc'], $this->requestInformation->getHeaders()->get('Authorization'));
+    }
+
+    public function testAuthenticateRequestRemovesHeaderWithClaims(): void
+    {
+        $this->requestInformation->getHeaders()->add('Authorization', 'Bearer 123');
+        $this->baseBearerTokenAuthenticationProvider->authenticateRequest($this->requestInformation, ['claims' => 'eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiYzEifX19'])->wait();
+        $this->assertTrue($this->requestInformation->getHeaders()->contains('Authorization'));
+        $this->assertEquals(['Bearer abc'], $this->requestInformation->getHeaders()->get('Authorization'));
+    }
+
+
+}


### PR DESCRIPTION
- Adds parameter to allow authentication layer to receive the claims returned by a resource e.g. Graph when the user's/applications access has changed/been revoked. These claims will be used by the auth lib to get a new access token.

- Removes existing auth header in requests if additional context contains claims. Shows that previous auth header was rejected, hence remove from request.

part of https://github.com/microsoft/kiota/issues/1590