### PR TITLE
Remove unused abandoned dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"php-http/promise": "^1.1.0",
-		"php-http/message-factory": "^1.0.2",
 		"league/uri": "^6.5",
 		"doctrine/annotations": "^1.13 || ^2.0",
 		"ramsey/uuid": "^3 || ^4"


### PR DESCRIPTION
PHP-HTTP's message factory has been [abandoned](https://github.com/php-http/message-factory) in favor of an official PSR implementation - https://packagist.org/packages/psr/http-factory

We also don't directly use the dependency. It's a downstream dependency.
Unit tests seem to be ok.