### PR TITLE
Add util to validate type of collection values

### DIFF
--- a/src/Types/TypeUtils.php
+++ b/src/Types/TypeUtils.php
@@ -30,7 +30,7 @@ class TypeUtils
             foreach ($values as $value) {
                 $debugType = get_debug_type($value);
                 if ($type !== $debugType) {
-                    throw new UnexpectedValueException("Collection of type=$type contains value of type=$type");
+                    throw new UnexpectedValueException("Collection of type=$type contains value of type=$debugType");
                 }
             }
         }

--- a/src/Types/TypeUtils.php
+++ b/src/Types/TypeUtils.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.
+ * Licensed under the MIT License.  See License in the project root
+ * for license information.
+ */
+
+
+namespace Microsoft\Kiota\Abstractions\Types;
+
+use UnexpectedValueException;
+
+/**
+ * Class TypeUtils
+ * @package Microsoft\Kiota\Abstractions\Types
+ * @copyright 2023 Microsoft Corporation
+ * @license https://opensource.org/licenses/MIT MIT License
+ * @link https://learn.microsoft.com/en-us/openapi/kiota/
+ */
+class TypeUtils
+{
+    /**
+     * Validates contents of a collection are of the expected $type
+     * @param array<mixed>|null $values
+     * @param string $type primitive type or class string
+     */
+    public static function validateCollectionValues($values, string $type): void
+    {
+        if (is_array($values)) {
+            foreach ($values as $value) {
+                $debugType = get_debug_type($value);
+                if ($type !== $debugType) {
+                    throw new UnexpectedValueException("Collection of type=$type contains value of type=$type");
+                }
+            }
+        }
+
+    }
+}

--- a/tests/Types/TypeUtilsTest.php
+++ b/tests/Types/TypeUtilsTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Microsoft\Kiota\Abstractions\Tests\Types;
+
+use Microsoft\Kiota\Abstractions\Types\TypeUtils;
+use PHPUnit\Framework\TestCase;
+
+class TypeUtilsTest extends TestCase
+{
+    public function testSuccessfulValidation(): void
+    {
+        $this->expectNotToPerformAssertions();
+        TypeUtils::validateCollectionValues([1, 2, 3], 'int');
+        TypeUtils::validateCollectionValues(['hello', 'world'], 'string');
+        TypeUtils::validateCollectionValues([1.2, 3.2], 'float');
+        TypeUtils::validateCollectionValues([true, false], 'bool');
+        TypeUtils::validateCollectionValues([new TestCustomType(), new TestCustomType()], TestCustomType::class);
+    }
+
+    public function testNullThrowsNoException(): void
+    {
+        $this->expectNotToPerformAssertions();
+        TypeUtils::validateCollectionValues(null, 'string');
+    }
+
+    public function testInvalidValueThrowsException(): void
+    {
+        $values = [
+            'string' => ['hello', 1],
+            'int' => [1, 1.2],
+            'bool' => [true, 1],
+            'float' => [1.2, 1],
+            TestCustomType::class => [new TestCustomType(), 1]
+        ];
+
+        foreach ($values as $key => $value) {
+            try {
+                TypeUtils::validateCollectionValues($value, $key);
+            } catch (\Exception $ex) {
+                $this->assertInstanceOf(\UnexpectedValueException::class, $ex);
+            }
+        }
+    }
+}
+
+class TestCustomType {
+
+}


### PR DESCRIPTION
Utility method to be called in generated model getters and setters that accept/return collections.

part of https://github.com/microsoft/kiota/issues/2378