### PR TITLE
Handle nulls when merging deserializers & serializing intersection wrappers

### DIFF
--- a/src/Serialization/ParseNodeHelper.php
+++ b/src/Serialization/ParseNodeHelper.php
@@ -6,21 +6,23 @@ class ParseNodeHelper
 {
     /**
      * Merge a collection of Parsable field deserializers.
-     * @param Parsable ...$targets
+     * @param Parsable|null ...$targets
      * @return array<string,callable(ParseNode):void>
      */
-    public static function mergeDeserializersForIntersectionWrapper(Parsable ...$targets): array
+    public static function mergeDeserializersForIntersectionWrapper(?Parsable ...$targets): array
     {
         if (empty($targets)) {
             return [];
         }
-        $result = $targets[0]->getFieldDeserializers();
-        for ($i = 1; $i < count($targets); $i++) {
-            $targetFieldDeserializers = $targets[$i]->getFieldDeserializers();
+        $result = [];
+        for ($i = 0; $i < count($targets); $i++) {
+            if ($targets[$i] !== null) {
+                $targetFieldDeserializers = $targets[$i]->getFieldDeserializers();
 
-            foreach ($targetFieldDeserializers as $key => $callable) {
-                if (!array_key_exists($key, $result)) {
-                    $result[$key] = $callable;
+                foreach ($targetFieldDeserializers as $key => $callable) {
+                    if (!array_key_exists($key, $result)) {
+                        $result[$key] = $callable;
+                    }
                 }
             }
         }

--- a/src/Serialization/SerializationWriter.php
+++ b/src/Serialization/SerializationWriter.php
@@ -56,9 +56,9 @@ interface SerializationWriter {
      * Writes the specified model object value to the stream with an optional given key.
      * @param string|null $key the key to write the value with.
      * @param Parsable|null $value the value to write to the stream.
-     * @param Parsable ...$additionalValuesToMerge additional Parsable values to merge.
+     * @param Parsable|null ...$additionalValuesToMerge additional Parsable values to merge.
      */
-    public function writeObjectValue(?string $key, ?Parsable $value, Parsable ...$additionalValuesToMerge): void;
+    public function writeObjectValue(?string $key, ?Parsable $value, ?Parsable ...$additionalValuesToMerge): void;
 
     /**
      * Gets the value of the serialized content.

--- a/tests/Serialization/ParseNodeHelperTest.php
+++ b/tests/Serialization/ParseNodeHelperTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Microsoft\Kiota\Abstractions\Tests\Serialization;
+
+use Microsoft\Kiota\Abstractions\Serialization\Parsable;
+use Microsoft\Kiota\Abstractions\Serialization\ParseNode;
+use Microsoft\Kiota\Abstractions\Serialization\ParseNodeHelper;
+use PHPUnit\Framework\TestCase;
+
+class ParseNodeHelperTest extends TestCase
+{
+    public function testMergeDeserializersForIntersectionWrapper(): void
+    {
+        $parsable1 = $this->createStub(Parsable::class);
+        $parsable1->method('getFieldDeserializers')
+            ->willReturn([
+               'x' => fn (ParseNode $n) => $n->setOnAfterAssignFieldValues(fn ($x) => strval($x))
+            ]);
+        $parsable2 = $this->createStub(Parsable::class);
+        $parsable2->method('getFieldDeserializers')
+            ->willReturn([
+                'y' => fn (ParseNode $n) => $n->setOnAfterAssignFieldValues(fn ($x) => strval($x))
+            ]);
+        $parsable3 = $this->createStub(Parsable::class);
+        $parsable3->method('getFieldDeserializers')
+            ->willReturn([
+                'x' => fn (ParseNode $n) => $n->setOnAfterAssignFieldValues(fn ($x) => intval($x))
+            ]);
+        $deserializers = ParseNodeHelper::mergeDeserializersForIntersectionWrapper($parsable1, null, $parsable2, null, $parsable3);
+        $this->assertEquals(
+            [
+                'x' => fn (ParseNode $n) => $n->setOnAfterAssignFieldValues(fn ($x) => strval($x)),
+                'y' => fn (ParseNode $n) => $n->setOnAfterAssignFieldValues(fn ($x) => strval($x))
+            ],
+            $deserializers
+        );
+    }
+
+}


### PR DESCRIPTION
part of https://github.com/microsoft/kiota/issues/2378

Makes it easier to handle generation of intersection wrappers where getters return nullables
![image](https://github.com/microsoft/kiota-abstractions-php/assets/10958912/b80544e7-4c9c-44a4-a3d5-3f59c36b0ca0)

![image](https://github.com/microsoft/kiota-abstractions-php/assets/10958912/3c6411a6-d484-42b2-8d24-37c84ebbc827)

