### PR TITLE
Validate derived types in collections

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,6 @@ parameters:
   polluteScopeWithLoopInitialAssignments: false
   paths:
     - src
+  reportUnmatchedIgnoredErrors: false
+  ignoreErrors:
+    - '/^Parameter #1 \$[A-Za-z_0-9]+ of function is_subclass_of expects object\|string, mixed given.$/'

--- a/src/Types/TypeUtils.php
+++ b/src/Types/TypeUtils.php
@@ -29,7 +29,7 @@ class TypeUtils
         if (is_array($values)) {
             foreach ($values as $value) {
                 $debugType = get_debug_type($value);
-                if ($type !== $debugType) {
+                if ($type !== $debugType && !is_subclass_of($value, $type)) {
                     throw new UnexpectedValueException("Collection of type=$type contains value of type=$debugType");
                 }
             }

--- a/tests/Types/TypeUtilsTest.php
+++ b/tests/Types/TypeUtilsTest.php
@@ -41,8 +41,23 @@ class TypeUtilsTest extends TestCase
             }
         }
     }
+
+    public function testValidationWithChildClasses(): void
+    {
+        $this->expectNotToPerformAssertions();
+        TypeUtils::validateCollectionValues([new ChildCustomType(), new ChildCustomType()], TestCustomType::class);
+        TypeUtils::validateCollectionValues([new ChildCustomType(), new ChildCustomType()], TestInterface::class);
+    }
 }
 
 class TestCustomType {
+
+}
+
+class ChildCustomType extends TestCustomType implements TestInterface {
+
+}
+
+interface TestInterface {
 
 }


### PR DESCRIPTION
We were previously not considering if a custom type is a child class or implements some interface.
Error caught when validating snippets.