### PR TITLE
Add default content-type value when setting stream content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - exposed the tryAdd method of request headers through request info.
 
+### Changed
+- Defaults the content type parameter in `setStreamContent` to `application/octet-stream`
+
 ## [0.8.3] - 2023-10-11
 
 ### Added

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -4,5 +4,5 @@ namespace Microsoft\Kiota\Abstractions;
 
 final class Constants
 {
-    public const VERSION = '0.8.3';
+    public const VERSION = '0.8.4';
 }

--- a/src/RequestInformation.php
+++ b/src/RequestInformation.php
@@ -150,7 +150,7 @@ class RequestInformation {
      * @param StreamInterface $value the binary stream
      * @param string $contentType the content type of the stream
      */
-    public function setStreamContent(StreamInterface $value, string $contentType = "application/octet-stream"): void {
+    public function setStreamContent(StreamInterface $value, string $contentType = 'application/octet-stream'): void {
         if (empty(trim($contentType))) {
             $contentType = self::$binaryContentType;
         }

--- a/src/RequestInformation.php
+++ b/src/RequestInformation.php
@@ -150,7 +150,7 @@ class RequestInformation {
      * @param StreamInterface $value the binary stream
      * @param string $contentType the content type of the stream
      */
-    public function setStreamContent(StreamInterface $value, string $contentType): void {
+    public function setStreamContent(StreamInterface $value, string $contentType = "application/octet-stream"): void {
         if (empty(trim($contentType))) {
             $contentType = self::$binaryContentType;
         }


### PR DESCRIPTION
We missed adding a minor version bump to the previous release by adding a required contentType parameter with no default value causing errors on Graph Core & Graph preview service libs

This adds a default value for the parameter.

@baywet would adding this default match the desired functionality?