### PR TITLE
Fix backing store dirty tracking for BackedModel and array<BackedModel> properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds generic types to Promise types in PHPDocs
 
 ### Changed
+- Ensure changes to nested BackedModel or array<BackedModel> properties in the backing store makes the entire backing store value dirty.
 
 ## [0.8.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+## [0.9.0] - 2023-10-30
+
+### Added
 - Adds generic types to Promise types in PHPDocs
 
 ### Changed
 - Ensure changes to nested BackedModel or array<BackedModel> properties in the backing store makes the entire backing store value dirty.
 
-## [0.8.5]
+## [0.8.5] - 2023-10-17
 
 ### Changed
 - Disabled auto-suggestion of PSR implementations by OpenTelemetry SDK. [#95](https://github.com/microsoft/kiota-abstractions-php/pull/95)

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -4,5 +4,5 @@ namespace Microsoft\Kiota\Abstractions;
 
 final class Constants
 {
-    public const VERSION = '0.8.5';
+    public const VERSION = '0.9.0';
 }

--- a/src/Store/InMemoryBackingStore.php
+++ b/src/Store/InMemoryBackingStore.php
@@ -38,7 +38,8 @@ class InMemoryBackingStore implements BackingStore
     public function set(string $key, $value): void
     {
         $oldValue = $this->store[$key] ?? null;
-        $valueToAdd = is_array($value) ? [$this->isInitializationCompleted, $value, count($value)] : [$this->isInitializationCompleted, $value];
+        $valueToAdd = is_array($value) ?
+            [$this->isInitializationCompleted, $value, count($value)] : [$this->isInitializationCompleted, $value];
 
         // Dirty track changes if $value is a model and its properties change
         if (!array_key_exists($key, $this->store)) {
@@ -52,7 +53,8 @@ class InMemoryBackingStore implements BackingStore
             if (is_array($value)) {
                 array_map(function ($item) use ($key, $value) {
                     if ($item instanceof BackedModel && $item->getBackingStore()) {
-                        $item->getBackingStore()->subscribe(function ($propertyKey, $oldVal, $newVal) use ($key, $value, $item) {
+                        $item->getBackingStore()->subscribe
+                        (function ($propertyKey, $oldVal, $newVal) use ($key, $value, $item) {
                             // Mark all properties as dirty
                             $item->getBackingStore()->setIsInitializationCompleted(false);
                             $this->set($key, $value);
@@ -199,11 +201,13 @@ class InMemoryBackingStore implements BackingStore
         if ($wrapper) {
             if (is_array($wrapper[1])) {
                 array_map(function ($item) {
-                    if ($item instanceof BackedModel) {
-                        if ($item->getBackingStore()) {
-                            // Call get() on nested properties so that this method may be called recursively to ensure collections are consistent
-                            array_map(fn ($itemKey) => $item->getBackingStore()->get($itemKey), array_keys($item->getBackingStore()->enumerate()));
-                        }
+                    if ($item instanceof BackedModel && $item->getBackingStore()) {
+                        // Call get() on nested properties so that this method may be called recursively
+                        // to ensure collections are consistent
+                        array_map(
+                            fn ($itemKey) => $item->getBackingStore()->get($itemKey),
+                            array_keys($item->getBackingStore()->enumerate())
+                        );
                     }
                 }, $wrapper[1]);
 
@@ -211,11 +215,13 @@ class InMemoryBackingStore implements BackingStore
                     $this->set($key, $wrapper[1]);
                 }
             }
-            if ($wrapper[1] instanceof BackedModel) {
-                // Call get() on nested properties so that this method may be called recursively to ensure collections are consistent
-                if ($wrapper[1]->getBackingStore()) {
-                    array_map(fn ($itemKey) => $wrapper[1]->getBackingStore()->get($itemKey), array_keys($wrapper[1]->getBackingStore()->enumerate()));
-                }
+            if ($wrapper[1] instanceof BackedModel && $wrapper[1]->getBackingStore()) {
+                // Call get() on nested properties so that this method may be called recursively
+                // to ensure collections are consistent
+                array_map(
+                    fn ($itemKey) => $wrapper[1]->getBackingStore()->get($itemKey),
+                    array_keys($wrapper[1]->getBackingStore()->enumerate())
+                );
             }
         }
     }

--- a/src/Store/InMemoryBackingStore.php
+++ b/src/Store/InMemoryBackingStore.php
@@ -43,12 +43,20 @@ class InMemoryBackingStore implements BackingStore
         // Dirty track changes if $value is a model and its properties change
         if (!array_key_exists($key, $this->store)) {
             if ($value instanceof BackedModel && $value->getBackingStore()) {
-                $value->getBackingStore()->subscribe(fn ($propertyKey, $oldVal, $newVal) => $this->set($key, $value));
+                $value->getBackingStore()->subscribe(function ($propertyKey, $oldVal, $newVal) use ($key, $value) {
+                    // Mark all properties as dirty
+                    $value->getBackingStore()->setIsInitializationCompleted(false);
+                    $this->set($key, $value);
+                });
             }
             if (is_array($value)) {
                 array_map(function ($item) use ($key, $value) {
                     if ($item instanceof BackedModel && $item->getBackingStore()) {
-                        $item->getBackingStore()->subscribe(fn ($propertyKey, $oldVal, $newVal) => $this->set($key, $value));
+                        $item->getBackingStore()->subscribe(function ($propertyKey, $oldVal, $newVal) use ($key, $value, $item) {
+                            // Mark all properties as dirty
+                            $item->getBackingStore()->setIsInitializationCompleted(false);
+                            $this->set($key, $value);
+                        });
                     }
                 }, $value);
             }
@@ -113,6 +121,20 @@ class InMemoryBackingStore implements BackingStore
      */
     public function setIsInitializationCompleted(bool $value): void {
         $this->isInitializationCompleted = $value;
+        // Update existing values in store
+        foreach ($this->store as $key => $storedValue) {
+            $storedValue[0] = !$storedValue[0];
+            if ($storedValue[1] instanceof BackedModel && $storedValue[1]->getBackingStore()) {
+                $storedValue[1]->getBackingStore()->setIsInitializationCompleted($value);
+            }
+            if (is_array($storedValue[1])) {
+                array_map(function ($item) use ($value) {
+                    if ($item instanceof BackedModel && $item->getBackingStore()) {
+                        $item->getBackingStore()->setIsInitializationCompleted($value);
+                    }
+                }, $storedValue[1]);
+            }
+        }
     }
 
     /**
@@ -174,9 +196,26 @@ class InMemoryBackingStore implements BackingStore
      */
     private function checkCollectionSizeChanged(string $key): void {
         $wrapper = $this->store[$key] ?? null;
-        if ($wrapper && is_array($wrapper[1])) {
-            if (sizeof($wrapper[1]) != $wrapper[2]) {
-                $this->set($key, $wrapper[1]);
+        if ($wrapper) {
+            if (is_array($wrapper[1])) {
+                array_map(function ($item) {
+                    if ($item instanceof BackedModel) {
+                        if ($item->getBackingStore()) {
+                            // Call get() on nested properties so that this method may be called recursively to ensure collections are consistent
+                            array_map(fn ($itemKey) => $item->getBackingStore()->get($itemKey), array_keys($item->getBackingStore()->enumerate()));
+                        }
+                    }
+                }, $wrapper[1]);
+
+                if (sizeof($wrapper[1]) != $wrapper[2]) {
+                    $this->set($key, $wrapper[1]);
+                }
+            }
+            if ($wrapper[1] instanceof BackedModel) {
+                // Call get() on nested properties so that this method may be called recursively to ensure collections are consistent
+                if ($wrapper[1]->getBackingStore()) {
+                    array_map(fn ($itemKey) => $wrapper[1]->getBackingStore()->get($itemKey), array_keys($wrapper[1]->getBackingStore()->enumerate()));
+                }
             }
         }
     }

--- a/tests/Store/InMemoryBackingStoreTest.php
+++ b/tests/Store/InMemoryBackingStoreTest.php
@@ -153,10 +153,7 @@ class InMemoryBackingStoreTest extends TestCase
 
     public function testChangesToBackedModelAsBackingStoreValueMakesEntireModelDirty(): void
     {
-        $nestedBackedModel = new SampleBackedModel();
-        $nestedBackedModel->setName('name');
-        $nestedBackedModel->setAge(10);
-        $nestedBackedModel->getBackingStore()->setIsInitializationCompleted(true);
+        $nestedBackedModel = new SampleBackedModel(10, 'name');
 
         $this->backingStore->set('user', $nestedBackedModel);
         $this->backingStore->setIsInitializationCompleted(true);
@@ -172,12 +169,10 @@ class InMemoryBackingStoreTest extends TestCase
 
     public function testChangesToBackedModelCollectionAsBackingStoreValueMakesEntireModelDirty(): void
     {
-        $nestedBackedModel = new SampleBackedModel();
-        $nestedBackedModel->setName('name');
-        $nestedBackedModel->setAge(10);
-        $nestedBackedModel->getBackingStore()->setIsInitializationCompleted(true);
+        $nestedBackedModel = new SampleBackedModel(10, 'name');
+        $anotherNestedBackedModel = new SampleBackedModel(100, 'FirstName');
 
-        $this->backingStore->set('user', [$nestedBackedModel, clone $nestedBackedModel]);
+        $this->backingStore->set('user', [$nestedBackedModel, $anotherNestedBackedModel]);
         $this->backingStore->setIsInitializationCompleted(true);
 
         $nestedBackedModel->setAge(5);
@@ -187,6 +182,7 @@ class InMemoryBackingStoreTest extends TestCase
 
         $this->assertIsArray($this->backingStore->get('user'));
         $this->assertEquals(2, sizeof($this->backingStore->get('user')));
+        $this->assertEquals(2, sizeof(array_keys($this->backingStore->get('user')[0]->getBackingStore()->enumerate())));
         $this->assertEquals(2, sizeof(array_keys($this->backingStore->get('user')[1]->getBackingStore()->enumerate())));
     }
 }


### PR DESCRIPTION
closes https://github.com/microsoft/kiota-abstractions-php/issues/102

ports similar fixes made in https://github.com/microsoft/kiota-abstractions-dotnet/pull/84