### PR TITLE
Init url template to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.1]
+
+### Changed
+- Initialises URL Template in Request Information to empty string. [#111](https://github.com/microsoft/kiota-abstractions-php/pull/111)
+
 ## [1.0.0] - 2023-11-01
 
 ### Changed

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -4,5 +4,5 @@ namespace Microsoft\Kiota\Abstractions;
 
 final class Constants
 {
-    public const VERSION = '1.0.0';
+    public const VERSION = '1.0.1';
 }

--- a/src/RequestInformation.php
+++ b/src/RequestInformation.php
@@ -17,7 +17,7 @@ class RequestInformation {
     /** @var string $RAW_URL_KEY */
     public static string $RAW_URL_KEY = 'request-raw-url';
     /** @var string $urlTemplate The url template for the current request */
-    public string $urlTemplate;
+    public string $urlTemplate = '';
     /**
      * The path parameters for the current request
      * @var array<string,mixed> $pathParameters


### PR DESCRIPTION
Prevents exception when [starting tracing](https://github.com/microsoft/kiota-http-guzzle-php/blob/dev/src/GuzzleRequestAdapter.php#L679) especially when a URL has been set without a URL template used e.g. during [page iteration](https://github.com/microsoftgraph/msgraph-sdk-php-core/blob/dev/src/Tasks/PageIterator.php#L180) 