### PR TITLE
Depend on promises 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"php-http/promise": "^1.2.0",
+		"php-http/promise": "~1.2.0",
 		"doctrine/annotations": "^1.13 || ^2.0",
 		"open-telemetry/sdk": "^1.0.0",
 		"ramsey/uuid": "^3 || ^4",


### PR DESCRIPTION
- Locks promises dependency to 1.2.0 while allowing patch updates.
- Temporary fix since generics were reverted in the promises package in [version 1.3](https://github.com/php-http/promise/releases/tag/1.3.0)