### PR TITLE
Require php-http/promise 1.3.0 to be compatible with PHP 8.4

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	},
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"php-http/promise": "~1.2.0",
+		"php-http/promise": "~1.3.0",
 		"doctrine/annotations": "^1.13 || ^2.0",
 		"open-telemetry/sdk": "^1.0.0",
 		"ramsey/uuid": "^4.2.3",


### PR DESCRIPTION
php-http/promise version 1.3.1 fixed compatibility issues with PHP 8.4. This pull request updates composer.json to allow installing this version of the php-http/promise library