### PR TITLE
Handle map-style query parameters with null values

### DIFF
--- a/src/RequestInformation.php
+++ b/src/RequestInformation.php
@@ -112,8 +112,21 @@ class RequestInformation {
         if (is_object($value) && is_subclass_of($value, Enum::class)) {
             return $value->value();
         }
-        return is_array($value) ?
-            array_map(fn ($x) => $this->sanitizeValue($x), $value) : $value;
+        if (is_array($value)) {
+            if (!array_is_list($value)) {
+                // Associative array (map-style query parameter): drop null entries per
+                // RFC 6570 §2.3 "undefined" semantics, then normalise remaining values.
+                $result = [];
+                foreach ($value as $k => $v) {
+                    if ($v !== null) {
+                        $result[(string)$k] = $this->sanitizeValue($v);
+                    }
+                }
+                return $result;
+            }
+            return array_map(fn ($x) => $this->sanitizeValue($x), $value);
+        }
+        return $value;
     }
 
     /**

--- a/tests/RequestInformationTest.php
+++ b/tests/RequestInformationTest.php
@@ -270,6 +270,112 @@ class RequestInformationTest extends TestCase {
         $this->assertEquals(1, count($res));
         $this->assertEquals("value1", $res[0]);
     }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testExpandsMapQueryParameterAsIndividualKeyValuePairs(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*}';
+        $requestInfo->queryParameters['query'] = [
+            'filter' => 'equals(published,true)',
+            'sort'   => '-createdAt',
+        ];
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringContainsString('?', $uri);
+        $this->assertStringContainsString('filter=equals%28published%2Ctrue%29', $uri);
+        $this->assertStringContainsString('sort=-createdAt', $uri);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testMapQueryParameterNullValuesAreOmitted(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*}';
+        $requestInfo->queryParameters['query'] = [
+            'include' => 'author',
+            'exclude' => null,
+        ];
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringContainsString('include=author', $uri);
+        $this->assertStringNotContainsString('exclude', $uri);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testMapQueryParameterEmptyStringValueIsIncluded(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*}';
+        $requestInfo->queryParameters['query'] = ['search' => ''];
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringContainsString('search=', $uri);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testEmptyMapQueryParameterProducesNoQueryString(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*}';
+        $requestInfo->queryParameters['query'] = [];
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringNotContainsString('?', $uri);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testAllNullMapQueryParameterProducesNoQueryString(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*}';
+        $requestInfo->queryParameters['query'] = ['a' => null, 'b' => null];
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringNotContainsString('?', $uri);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testMixOfMapAndScalarQueryParameters(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*,top}';
+        $requestInfo->queryParameters['query'] = ['filter' => 'active'];
+        $requestInfo->queryParameters['top']   = 5;
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringContainsString('filter=active', $uri);
+        $this->assertStringContainsString('top=5', $uri);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function testMapQueryParameterViaSetQueryParameters(): void {
+        $requestInfo = new RequestInformation();
+        $requestInfo->urlTemplate = 'http://localhost/articles{?query*}';
+
+        $queryParam = new TestMapQueryParameter();
+        $queryParam->query = ['filter' => 'equals(published,true)', 'sort' => '-createdAt'];
+        $requestInfo->setQueryParameters($queryParam);
+
+        $uri = $requestInfo->getUri();
+
+        $this->assertStringContainsString('filter=equals%28published%2Ctrue%29', $uri);
+        $this->assertStringContainsString('sort=-createdAt', $uri);
+    }
 }
 
 class TestQueryParameter {
@@ -318,4 +424,9 @@ class TestFalsyQueryParameter {
 class TestEnum extends Enum {
     public const A = "a";
     public const B = "b";
+}
+
+class TestMapQueryParameter {
+    /** @var array<string,string|null>|null */
+    public ?array $query = null;
 }


### PR DESCRIPTION
Contributes to https://github.com/microsoft/kiota/issues/3800.

Associative arrays used as map/dictionary query parameters (from an OpenAPI 	ype: object with dditionalProperties field) are now sanitized before being passed to StdUriTemplate. Null values are silently dropped per RFC 6570 §2.3 "undefined" semantics, preventing an InvalidArgumentException when StdUriTemplate tries to convert null to a string. An empty string must be set explicitly to send key=.

Adds seven test cases covering map expansion, null-value omission, empty-string inclusion, empty maps, all-null maps, mixed scalar+map parameters, and the setQueryParameters() path.